### PR TITLE
msm: adsprpc: Fix deadlock during SSR

### DIFF
--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -2568,12 +2568,17 @@ static int fastrpc_mmap_remove_ssr(struct fastrpc_file *fl)
 					kfree(ramdump_segments_rh);
 				}
 			}
+			mutex_lock(&fl->map_mutex);
 			fastrpc_mmap_free(match, 0);
+			mutex_unlock(&fl->map_mutex);
 		}
 	} while (match);
 bail:
-	if (err && match)
+	if (err && match) {
+		mutex_lock(&fl->map_mutex);
 		fastrpc_mmap_add(match);
+		mutex_unlock(&fl->map_mutex);
+	}
 	return err;
 }
 
@@ -3316,11 +3321,12 @@ static int fastrpc_channel_open(struct fastrpc_file *fl)
 
 	if (cid == ADSP_DOMAIN_ID && me->channel[cid].ssrcount !=
 			 me->channel[cid].prevssrcount) {
-		mutex_lock(&fl->map_mutex);
-		if (fastrpc_mmap_remove_ssr(fl))
+		mutex_unlock(&me->channel[cid].smd_mutex);
+		if (fastrpc_mmap_remove_ssr(fl)) {
 			pr_err("adsprpc: %s: SSR: Failed to unmap remote heap for %s\n",
 				__func__, me->channel[cid].name);
-		mutex_unlock(&fl->map_mutex);
+		}
+		mutex_lock(&me->channel[cid].smd_mutex);
 		me->channel[cid].prevssrcount =
 					me->channel[cid].ssrcount;
 	}


### PR DESCRIPTION
Deadlock is happening because map_mutex and smd_mutex lock is
acquired before fastrpc_mmap_remove_ssr() call and inside again
in get_args() and fastrpc_invoke_send() respectively. Added
lock only to critical sections in need.